### PR TITLE
chore: :wrench: Create wp-cli.yml

### DIFF
--- a/docs/setup/wordpress-guides.md
+++ b/docs/setup/wordpress-guides.md
@@ -29,7 +29,7 @@ Composer will automatically run while deploying to staging/production.
 ## WP CLI
 
 You can use all the power of **wp-cli** in your terminal by running any wp-cli commands within the docker container.
-For example: `docker exec spck_wp wp user list`
+For example: `docker exec spck_wp wp user list` or with alias **@local** like `wp @local user list`
 
 > [Read more](https://developer.wordpress.org/cli/commands/) about running commands inside WordPress containers.
 

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,10 @@
+# WP-CLI aliases see doc for more info https://make.wordpress.org/cli/handbook/guides/running-commands-remotely/#aliases
+
+# Don't change @local alias structure to have it working with docker
+# ssh value should remain in one line (docker:container_name/wp_install_path)
+@local:
+  ssh: 'docker:spck_wp/var/www/html'
+
+# @staging:
+#     ssh: user@server.com
+#     path: /absolute-path/web/staging


### PR DESCRIPTION
Fixes #10 

I included the file at the root of the project to be able to run wpcli command not only inside the wordpress folder