### PR TITLE
chore: :wrench: Fix installation instructions for wordpress

### DIFF
--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -9,6 +9,7 @@ Follow these steps to install the stack for the 1st time:
 
 ### WordPress
 
+-   `cp ./wordpress/auth.json.example ./wordpress/auth.json && sed -i '' -e 's/##username##/__LOGIN__/g' -e 's/##password##/__PASSWORD__/g' ./wordpress/auth.json` - Setup the auth for pro plugin (do not forget to replace `__LOGIN__` & `__PASSWORD__` with actual credentials)
 -   `cd wordpress`
 -   `npm run build:assets`
 -   `npm run start:wp`

--- a/wordpress/auth.json.example
+++ b/wordpress/auth.json.example
@@ -1,0 +1,8 @@
+{
+	"http-basic": {
+		"release-belt.superhuit.ch": {
+			"username": "##username##",
+			"password": "##password##"
+		}
+	}
+}


### PR DESCRIPTION
auth.json file should be configured before to start the stack, not after the docker has starter