### PR TITLE
chore: :hammer: Simplify wordpress scripts to follow nextjs nomenclature

### DIFF
--- a/.github/actions/build-theme/action.yml
+++ b/.github/actions/build-theme/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Build assets
       shell: bash
-      run: npm run build:assets
+      run: npm run build
       working-directory: ./wordpress
 
     # - name: Execute script to update translation file

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ An opinionated boilerplate for decoupled (headless) websites that are both perfo
 
 (inside `/wordpress` folder)
 
--   `npm run start:wp` - start WP server
--   `npm run stop:wp` - stop WP server
--   `npm run build:assets` - build Webpack for the assets on WP
--   `npm run start:assets` - start Webpack for the assets on WP (watch + hot reload)
+-   `npm run start` - start WP server
+-   `npm run stop` - stop WP server
+-   `npm run build` - build Webpack for the assets on WP
+-   `npm run dev` - start Webpack for the assets on WP (watch + hot reload)
 
 Open [http://localhost/wp-admin/](http://localhost/wp-admin/) on your browser to access to the admin. (login: **superstack**, password: **superstack**)
 

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -5,13 +5,12 @@ Follow these steps to install the stack for the 1st time:
 -   `cp .env.local.example .env.local` - make default environment variables available to Next.js, Storybook and WordPress
 -   `nvm use`
 -   `npm install` - install global packages
--   `cd wordpress && npm install` - install WordPress-specific packages
+-   `npm --prefix ./wordpress install` - install WordPress-specific packages
 
 ### WordPress
 
--   `cd wordpress`
--   `npm run build:assets`
--   `npm run start:wp`
+-   `npm --prefix ./wordpress run build`
+-   `npm --prefix ./wordpress run start`
 
 Open [http://localhost/wp-admin/](http://localhost/wp-admin/) on your browser to access to the admin. (login: **superstack**, password: **superstack**)
 

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -8,11 +8,11 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start:assets": "NEXT_PUBLIC_IS_THIS_NEXT=false NODE_ENV=development webpack server",
-    "start:wp": "THEME_NAME=superstack PROJECT_CODE=spck CONTAINER_NAME=spck_wp ./scripts/mutagen.sh up && docker-compose exec -T wp bash < ./scripts/provision.sh",
-    "stop:wp": "./scripts/mutagen.sh down",
+    "dev": "NEXT_PUBLIC_IS_THIS_NEXT=false NODE_ENV=development webpack server",
+    "start": "THEME_NAME=superstack PROJECT_CODE=spck CONTAINER_NAME=spck_wp ./scripts/mutagen.sh up && docker-compose exec -T wp bash < ./scripts/provision.sh",
+    "stop": "./scripts/mutagen.sh down",
     "logs": "docker compose logs -f",
-    "build:assets": "NEXT_PUBLIC_IS_THIS_NEXT=false NODE_ENV=production webpack",
+    "build": "NEXT_PUBLIC_IS_THIS_NEXT=false NODE_ENV=production webpack",
     "generate:pot": "wp i18n make-pot ./theme theme/languages/supt.pot",
     "generate:json": "wp i18n make-json ./theme/languages/fr_FR.po --no-purge",
     "analyze": "ANALYZE=true NODE_ENV=production webpack"


### PR DESCRIPTION
As discussed this morning 

- start:assets => dev 
- build:assets => build 
- start:wp => start 
- stop:wp => stop