### PR TITLE
Update deploy-next action to build next in CI

### DIFF
--- a/.github/actions/deploy-next/action.yml
+++ b/.github/actions/deploy-next/action.yml
@@ -24,13 +24,37 @@ inputs:
     description: 'The name of the pm2 process to start'
     required: true
   PM2_APP_ENV:
-    description: "The  pm2's env instance name. (Default: production)"
+    description: "The pm2's env instance name. (Default: production)"
     required: false
     default: 'production'
 
 runs:
   using: 'composite'
   steps:
+    - name: Install node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install node dependencies
+      shell: bash
+      run: npm ci
+
+    - name: Pull .env file
+      uses: up9cloud/action-rsync@master
+      env:
+        MODE: PULL
+        HOST: ${{ inputs.SSH_HOST }}
+        USER: ${{ inputs.SSH_USER }}
+        PORT: ${{ inputs.SSH_PORT }}
+        KEY: ${{ inputs.SSH_PRIVATE_KEY }}
+        SOURCE: ${{ inputs.NEXT_PATH }}/.env
+        TARGET: ./
+
+    - name: Build Next
+      shell: bash
+      run: NODE_ENV=production npm run build
+
     - name: Deploy
       uses: easingthemes/ssh-deploy@main
       with:
@@ -40,29 +64,8 @@ runs:
         REMOTE_PORT: ${{ inputs.SSH_PORT }}
         ARGS: -aulrqtvz
         SOURCE: .
-        TARGET: ${{ inputs.NEXT_PATH }}/_new
-        EXCLUDE: '.git*, .*ignore, .next, .storybook, .vscode, docs, generators, node_modules, wiki, wordpress, .editorconfig, .env.local.example, README.md, next-env.d.ts, vercel.json'
-
-    - name: Copy env file
-      uses: garygrossgarten/github-action-ssh@release
-      with:
-        username: ${{ inputs.SSH_USER }}
-        host: ${{ inputs.SSH_HOST }}
-        port: ${{ inputs.SSH_PORT }}
-        privateKey: ${{ inputs.SSH_PRIVATE_KEY }}
-        command: cp "${{ inputs.NEXT_PATH }}/public/.env" "${{ inputs.NEXT_PATH }}/_new/"
-
-    - name: Build
-      uses: garygrossgarten/github-action-ssh@release
-      with:
-        username: ${{ inputs.SSH_USER }}
-        host: ${{ inputs.SSH_HOST }}
-        port: ${{ inputs.SSH_PORT }}
-        privateKey: ${{ inputs.SSH_PRIVATE_KEY }}
-        command: |
-          cd "${{ inputs.NEXT_PATH }}/_new" 
-          npm install 
-          WORDPRESS_URL=${{ inputs.WORDPRESS_URL }} NODE_ENV=production npm run build
+        TARGET: ${{ inputs.NEXT_PATH }}/public
+        EXCLUDE: '.git*, .*ignore, .storybook, .vscode, docs, generators, wiki, .editorconfig, .env.github.example, .env.local.example, README.md, next-env.d.ts, vercel.json, wordpress'
 
     - name: Release
       uses: garygrossgarten/github-action-ssh@release
@@ -72,10 +75,6 @@ runs:
         port: ${{ inputs.SSH_PORT }}
         privateKey: ${{ inputs.SSH_PRIVATE_KEY }}
         command: |
-          cd ${{ inputs.NEXT_PATH }} 
-          [ -d "${{ inputs.NEXT_PATH }}/_previous" ] && rm -rf "${{ inputs.NEXT_PATH }}/_previous" 
-          mv "${{ inputs.NEXT_PATH }}/public" "${{ inputs.NEXT_PATH }}/_previous" 
-          mv "${{ inputs.NEXT_PATH }}/_new" "${{ inputs.NEXT_PATH }}/public"
-          cd "${{ inputs.NEXT_PATH }}/public" 
+          cd ${{ inputs.NEXT_PATH }}/public
           pm2 restart ecosystem.config.js --only ${{ inputs.PM2_APP_NAME }} --env ${{ inputs.PM2_APP_ENV }} 
           pm2 save


### PR DESCRIPTION
Fixes #22 

@charl0tee I took what you [did in pulse up](https://github.com/superhuit-agency/pulse-up/blob/client-staging/.github/actions/deploy-next-client-staging/action.yml) with a little adaptation.

- I didn't include the arguments `--chown=superhuit:superhuit --rsync-path="sudo rsync"` in the rsync command, which is really specific to Pulse-up
- I use `npm ci` instead of `npm install --frozen-lockfile` for two reasons
  1. `--frozen-lockfile` option does not exist for npm (it's only for yarn)
  2. npm clearly indicated that the ci command is better for ci worflows => https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable