### PR TITLE
fix(editor): :wrench: fonts loading WP editor

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -12,7 +12,7 @@
     "start": "sh ./scripts/start-wp.sh",
     "stop": "docker compose down",
     "logs": "docker compose logs -f",
-    "build": "NEXT_PUBLIC_IS_THIS_NEXT=false NODE_ENV=production webpack",
+    "build": "THEME_NAME=superstack NEXT_PUBLIC_IS_THIS_NEXT=false NODE_ENV=production webpack",
     "generate:pot": "wp i18n make-pot ./theme theme/languages/supt.pot",
     "generate:json": "wp i18n make-json ./theme/languages/fr_FR.po --no-purge",
     "analyze": "ANALYZE=true NODE_ENV=production webpack"

--- a/wordpress/theme/lib/SuptTheme.php
+++ b/wordpress/theme/lib/SuptTheme.php
@@ -122,7 +122,7 @@ class SuptTheme {
 		// OR webpack-dev-server is not running
 		// -> try to load from the filesystem  [/wp-content/themes/superstack/static/manifest.json]
 		elseif ( file_exists(THEME_PATH . '/static/manifest.json') && $manifest = json_decode(file_get_contents(THEME_PATH . '/static/manifest.json', true)) ) {
-			$assets_uri = THEME_URI . '/static/';
+			$assets_uri = THEME_URI . '/static';
 		}
 
 		// Manifest not found…

--- a/wordpress/webpack.config.js
+++ b/wordpress/webpack.config.js
@@ -193,7 +193,7 @@ module.exports = {
 				generator: {
 					publicPath: DEV
 						? undefined
-						: `/wp-content/themes/${process.env.THEME_NAME}/static/`, // Only override the public path specifically for fonts on PRODUCTION
+						: `/wp-content/themes/${process.env?.THEME_NAME ?? 'superstack'}/static/`, // Only override the public path specifically for fonts on PRODUCTION
 				},
 			},
 		],

--- a/wordpress/webpack.config.js
+++ b/wordpress/webpack.config.js
@@ -190,6 +190,11 @@ module.exports = {
 				test: /\.(woff|woff2|eot|ttf|otf)$/i,
 				include: path.resolve(__dirname, '../src/assets/fonts'),
 				type: 'asset',
+				generator: {
+					publicPath: DEV
+						? undefined
+						: `/wp-content/themes/${process.env.THEME_NAME}/static/`, // Only override the public path specifically for fonts on PRODUCTION
+				},
 			},
 		],
 	},


### PR DESCRIPTION
Fonts were not correctly loading in the editor due to the wrong public path when assets where built

Big up to @charl0tee https://github.com/superhuit-agency/pulse-up/commit/6cd28c41cb259fcc9f02b7ac7af0f8f9b33d3e26

## TODO
- [ ] Update internal doc to also rename THEME_NAME in `wordpress/package.json` for the `build` script