### PR TITLE
chore(#52): 🔧 Simplify setup process

### DIFF
--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -4,8 +4,7 @@ Follow these steps to install the stack for the 1st time:
 
 -   `cp .env.local.example .env.local` - make default environment variables available to Next.js, Storybook and WordPress
 -   `nvm use`
--   `npm install` - install global packages
--   `npm --prefix ./wordpress install` - install WordPress-specific packages
+-   `npm install` - install packages
 
 ### WordPress
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "npm --prefix ./wordpress install",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
Install both root & WP deps in a single command with `postinstall`npm life cycle script