### PR TITLE
Improve fetch-api

### DIFF
--- a/src/lib/fetch-api.ts
+++ b/src/lib/fetch-api.ts
@@ -28,37 +28,37 @@ const fetchAPI: FetchApiFuncType = async (query, options) => {
 	// // Debug performances
 	// const perfsId = fetchAPITester.markStart(`${type} - ${name}`);
 
-	// try {
-	const res = await fetch(endpoint, {
-		method: 'POST',
-		headers,
-		body: JSON.stringify({
-			query: dedupeFragments(query),
-			variables,
-		}),
-	});
+	try {
+		const res = await fetch(endpoint, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				query: dedupeFragments(query),
+				variables,
+			}),
+		});
 
-	const { data, errors } = await res.json();
+		const { data, errors } = await res.json();
 
-	if (errors) {
-		const limit = '=================';
-		const sep = '-----------------';
-		const date = new Date().toISOString();
-		const vars = JSON.stringify(variables, null, 2);
-		const errs = errors
-			.map((e: any) => `   - ${e.message} [${e.extensions.category}]`)
-			.join('\n');
+		if (errors) {
+			const limit = '=================';
+			const sep = '-----------------';
+			const date = new Date().toISOString();
+			const vars = JSON.stringify(variables, null, 2);
+			const errs = errors
+				.map((e: any) => `   - ${e.message} [${e.extensions.category}]`)
+				.join('\n');
 
-		throw new Error(
-			`\n${limit}\nGraphQl API error\n${sep}\n== date: ${date}\n== errors: \n${errs}\n== query: ${name}\n== variables: ${vars}\n${limit}\n`
+			throw new Error(
+				`\n${limit}\nGraphQl API error\n${sep}\n== date: ${date}\n== errors: \n${errs}\n== query: ${name}\n== variables: ${vars}\n${limit}\n`
+			);
+		}
+		result = data;
+	} catch (errors) {
+		(Array.isArray(errors) ? errors : [errors]).map((err) =>
+			console.error(err.message)
 		);
 	}
-	result = data;
-	// } catch (errors) {
-	// 	(Array.isArray(errors) ? errors : [errors]).map((err) =>
-	// 		console.error(err.message)
-	// 	);
-	// }
 
 	// // Debug performances
 	// fetchAPITester.markEnd(perfsId);

--- a/src/lib/fetch-api.ts
+++ b/src/lib/fetch-api.ts
@@ -58,7 +58,7 @@ const fetchAPI: FetchApiFuncType = async (query, options) => {
 		}
 
 		// Make sure to return the data if any
-		// event if there are some errors
+		// even if there are some errors
 		if (!!data) result = data;
 
 		if (errors) {

--- a/src/lib/fetch-api.ts
+++ b/src/lib/fetch-api.ts
@@ -57,6 +57,10 @@ const fetchAPI: FetchApiFuncType = async (query, options) => {
 			);
 		}
 
+		// Make sure to return the data if any
+		// event if there are some errors
+		if (!!data) result = data;
+
 		if (errors) {
 			const errs = errors
 				.map((e: any) => `\t- ${e.message} [${e.extensions.category}]`)


### PR DESCRIPTION
- restore try/catch in api-fetch 
- Improve error display
- handle errors of JSON parsing
- return fetched data even if there are errors in the response cc. @geck1942 

I did a quick check about the performances concern of first parsing to text then parsing to JSON vs directly parsing to JSON.
There is not significant deterioration or improvement in performances. I created a [quick jsperf test](https://jsperf.app/bacona) to compare.
Claude.ai also indicate that it should not change anything in perf, it's just a matter of readability

![Capture d’écran 2024-08-15 à 15 39 35](https://github.com/user-attachments/assets/1b8613a7-740d-478d-8c98-271b65474509)
