### PR TITLE
fix: :bug: Update starterpack-forms plugins to match current codebase

### DIFF
--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -26,7 +26,7 @@
 		"pristas-peter/wp-graphql-gutenberg": "dev-master",
 		"superhuit/wp-graphql-redirection": "^1.1",
 		"superhuit-agency/nextjs-revalidate": "^1.6.4",
-		"superhuit-agency/starterpack-forms": "^1.0",
+		"superhuit-agency/starterpack-forms": "^1.1",
 		"valu/wp-graphql-offset-pagination": "dev-master",
 		"wp-graphql/wp-graphql-jwt-authentication": "^0.7.0",
 		"wpackagist-plugin/disable-comments": "^2.4",
@@ -55,10 +55,10 @@
 			"type": "package",
 			"package": {
 				"name": "superhuit-agency/starterpack-forms",
-				"version": "1.0.17",
+				"version": "1.1.0",
 				"type": "wordpress-plugin",
 				"dist": {
-					"url": "https://github.com/superhuit-agency/starterpack-forms/releases/download/v1.0.17/starterpack-forms-v1.0.17.zip",
+					"url": "https://github.com/superhuit-agency/starterpack-forms/releases/download/v1.1.0/starterpack-forms-v1.1.0.zip",
 					"type": "zip"
 				}
 			}

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18727be93acd2393a55eb628666a01d3",
+    "content-hash": "d0251793d27e59beaf0cbd4ea08e31f6",
     "packages": [
         {
             "name": "ashhitch/wp-graphql-yoast-seo",
@@ -678,10 +678,10 @@
         },
         {
             "name": "superhuit-agency/starterpack-forms",
-            "version": "1.0.17",
+            "version": "1.1.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/superhuit-agency/starterpack-forms/releases/download/v1.0.17/starterpack-forms-v1.0.17.zip"
+                "url": "https://github.com/superhuit-agency/starterpack-forms/releases/download/v1.1.0/starterpack-forms-v1.1.0.zip"
             },
             "type": "wordpress-plugin"
         },


### PR DESCRIPTION
There was a mismatch between the current codebase and the Starterpack Forms plugin version (API fetch vs/ GraphQL)
=> problem encountered while testing Bredam on Superstack