### PR TITLE
✨ feat: add cookie banner analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@formatjs/intl-localematcher": "^0.6.0",
         "@hcaptcha/react-hcaptcha": "^1.10.1",
         "@next/bundle-analyzer": "^14.2.5",
+        "@next/third-parties": "^16.1.6",
         "classnames": "^2.5.1",
         "filesize": "^10.1.0",
         "js-cookie": "^3.0.5",
@@ -166,6 +167,7 @@
       "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -2512,6 +2514,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2534,6 +2537,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -3506,6 +3510,7 @@
       "version": "11.11.3",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.3.tgz",
       "integrity": "sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -4044,6 +4049,19 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/third-parties": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.1.6.tgz",
+      "integrity": "sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4144,6 +4162,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5169,6 +5188,7 @@
       "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5573,6 +5593,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6582,6 +6603,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6925,6 +6947,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6983,6 +7006,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7519,6 +7543,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8060,6 +8085,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001640",
         "electron-to-chromium": "^1.4.820",
@@ -9814,6 +9840,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9925,6 +9952,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10077,6 +10105,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -13586,6 +13615,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
       "integrity": "sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.2.5",
         "@swc/helpers": "0.5.5",
@@ -15197,6 +15227,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -16224,6 +16255,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
       "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16510,6 +16542,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16595,6 +16628,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -16653,6 +16687,7 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16802,6 +16837,7 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -17875,6 +17911,7 @@
       "integrity": "sha512-8j30wDxQmkcqI0fWcSYFsUCjErsY1yTWbTW+yjbwM8DyW18Cud6CwbFRCxjFsH+2M0CjP6Pqs/m1PGI0vcQscQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/types": "^7.24.0",
@@ -18925,6 +18962,12 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
+    },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -19150,6 +19193,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -19249,6 +19293,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19702,6 +19747,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.3.tgz",
       "integrity": "sha512-h6uDYlWCctQRuXBs1oYpVe6sFcWedl0dpcVaTf/YF67J9bKvwJajFulMVSYKHrksMB3I/pIagRzDxwxkebuzKA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
@@ -19860,6 +19906,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19917,6 +19964,7 @@
       "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",
@@ -19950,6 +19998,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@formatjs/intl-localematcher": "^0.6.0",
     "@hcaptcha/react-hcaptcha": "^1.10.1",
     "@next/bundle-analyzer": "^14.2.5",
+    "@next/third-parties": "^16.1.6",
     "classnames": "^2.5.1",
     "filesize": "^10.1.0",
     "js-cookie": "^3.0.5",

--- a/src/app/api/cookie-stats/route.ts
+++ b/src/app/api/cookie-stats/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getWpUrl } from '@/utils/node-utils';
+
+const ALLOWED_EVENTS = ['impression', 'accept', 'reject', 'personalize'];
+
+/**
+ * Resolve the real visitor IP from available headers.
+ * Order of priority:
+ *  1. x-forwarded-for (set by reverse proxies / load balancers)
+ *  2. x-real-ip (set by some proxies like nginx)
+ *  3. Next.js request.ip (available in some runtimes)
+ */
+function getVisitorIp(request: NextRequest): string {
+	const forwardedFor = request.headers.get('x-forwarded-for');
+	if (forwardedFor) {
+		return forwardedFor.split(',')[0].trim();
+	}
+
+	const realIp = request.headers.get('x-real-ip');
+	if (realIp) {
+		return realIp.trim();
+	}
+
+	// Next.js built-in (works on Vercel and some other platforms)
+	if (request.ip) {
+		return request.ip;
+	}
+
+	return '';
+}
+
+export async function POST(request: NextRequest) {
+	try {
+		const body = await request.json();
+		const { event_type } = body;
+
+		if (!event_type || !ALLOWED_EVENTS.includes(event_type)) {
+			return NextResponse.json(
+				{ success: false, message: 'Invalid event type.' },
+				{ status: 400 }
+			);
+		}
+
+		const visitorIp = getVisitorIp(request);
+		const userAgent = request.headers.get('user-agent') || '';
+
+		// Forward the request to WordPress REST API
+		const wpUrl = getWpUrl();
+		const response = await fetch(`${wpUrl}/wp-json/supt/v1/cookie-stats`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				...(visitorIp ? { 'X-Forwarded-For': visitorIp } : {}),
+				...(userAgent ? { 'User-Agent': userAgent } : {}),
+			},
+			body: JSON.stringify({ event_type }),
+		});
+
+		const data = await response.json();
+
+		return NextResponse.json(data, { status: response.status });
+	} catch {
+		// Silent fail - analytics should not break anything
+		return NextResponse.json({ success: false }, { status: 500 });
+	}
+}

--- a/src/components/molecules/Gdpr/index.tsx
+++ b/src/components/molecules/Gdpr/index.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import Cookies from 'js-cookie';
-import Script from 'next/script';
+import { GoogleTagManager, sendGTMEvent } from '@next/third-parties/google';
 
 import { useLocale } from '@/contexts/locale-context';
 import gdprConfigs from '@/gdpr-configs.json';
@@ -24,15 +24,28 @@ const COOKIES_OPTIONS: Cookies.CookieAttributes = {
 const COOKIE_NAME = 'supt-cookie-law-consent';
 
 /**
+ * Track a cookie banner event via the internal API.
+ * Fire-and-forget: failures are silently ignored so analytics never break UX.
+ */
+const trackCookieEvent = (
+	eventType: 'impression' | 'accept' | 'reject' | 'personalize'
+) => {
+	fetch('/api/cookie-stats', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ event_type: eventType }),
+	}).catch(() => {
+		// Silent fail
+	});
+};
+
+/**
  * COMPONENT
  */
 export const Gdpr: FC<GdprProps> & BlockConfigs = () => {
 	const [categories, setCategories] = useState<GdprCategoryType[]>([]);
 	const [bannerDismissed, setBannerDismissed] = useState(true);
-	const [gdprServices, setGdprServices] = useState<Record<string, boolean>>(
-		{}
-	);
-
+	const [gdprServices, setGdprServices] = useState<any>({});
 	const { locale } = useLocale();
 
 	const services = useRef({});
@@ -45,11 +58,36 @@ export const Gdpr: FC<GdprProps> & BlockConfigs = () => {
 		) => {};
 	}>(null);
 
+	const setCategoryCookie = useCallback(
+		(category: { id: string; services?: string[] }, accepted = false) => {
+			Cookies.set(
+				`${COOKIE_NAME}_${category.id}_accepted`,
+				accepted ? ACCEPTED_VALUE : REFUSED_VALUE,
+				COOKIES_OPTIONS
+			);
+
+			if (category.services) {
+				category.services.forEach((name: string) => {
+					services.current = {
+						...services.current,
+						[name]: {
+							isAccepted: accepted,
+						},
+					};
+				});
+
+				setGdprServices(services.current); // Needs to be set from a ref to avoid overriding state that wasn't updated yet
+			}
+		},
+		[setGdprServices]
+	);
+
 	// ##############################
 	// #region Event handler
 	// ##############################
 
 	const onPersonalizeClick = useCallback(() => {
+		trackCookieEvent('personalize');
 		modalRef.current?.open();
 	}, []);
 
@@ -77,30 +115,8 @@ export const Gdpr: FC<GdprProps> & BlockConfigs = () => {
 
 	const onModalSaved = useCallback(() => {
 		setBannerDismissed(true);
-		Cookies.set(`${COOKIE_NAME}_banner`, 'dismiss', COOKIES_OPTIONS);
+		updateGTMConsent(gdprServices.googletagmanager?.isAccepted ?? false);
 	}, []);
-
-	const setCategoryCookie = useCallback(
-		(category: Record<string, any>, accepted = false) => {
-			Cookies.set(
-				`${COOKIE_NAME}_${category.id}_accepted`,
-				accepted ? ACCEPTED_VALUE : REFUSED_VALUE,
-				COOKIES_OPTIONS
-			);
-
-			if (category.services) {
-				category.services.forEach((name: string) => {
-					services.current = {
-						...services.current,
-						[name]: accepted,
-					};
-				});
-
-				setGdprServices(services.current); // Needs to be set from a ref to avoid overriding state that wasn't updated yet
-			}
-		},
-		[setGdprServices]
-	);
 
 	const onCategoryChange: GdprModalProps['onCategoryChange'] = useCallback(
 		({ enabled, id }) => {
@@ -116,23 +132,47 @@ export const Gdpr: FC<GdprProps> & BlockConfigs = () => {
 	// #endregion
 	// ##############################
 
-	const acceptAll = useCallback(() => {
+	// ##############################
+	// #region Google Consent Mode v2
+	// ##############################
+
+	const updateGTMConsent = useCallback((enabled: boolean = false) => {
+		if (typeof window === 'undefined' || typeof window.gtag !== 'function')
+			return;
+
+		sendGTMEvent({
+			event: 'consent',
+			value: 'update',
+			parameters: {
+				ad_storage: enabled ? 'granted' : 'denied',
+				ad_user_data: enabled ? 'granted' : 'denied',
+				ad_personalization: enabled ? 'granted' : 'denied',
+				analytics_storage: enabled ? 'granted' : 'denied',
+			},
+		});
+	}, []);
+
+	const acceptAll = () => {
+		trackCookieEvent('accept');
 		setBannerDismissed(true);
 		Cookies.set(`${COOKIE_NAME}_banner`, 'dismiss', COOKIES_OPTIONS);
 		gdprConfigs.categories.forEach((cat) => {
 			setCategoryCookie(cat, true);
 			modalRef.current?.setCategoryEnabled(cat, true);
+			updateGTMConsent(true);
 		});
-	}, [setCategoryCookie]);
+	};
 
-	const rejectAll = useCallback(() => {
+	const rejectAll = () => {
+		trackCookieEvent('reject');
 		setBannerDismissed(true);
 		Cookies.set(`${COOKIE_NAME}_banner`, 'dismiss', COOKIES_OPTIONS);
 		gdprConfigs.categories.forEach((cat) => {
 			setCategoryCookie(cat, false);
 			modalRef.current?.setCategoryEnabled(cat, false);
 		});
-	}, [setCategoryCookie]);
+		updateGTMConsent();
+	};
 
 	// TODO :: Move to category file ??
 	const getCategoriesSettings = useCallback(() => {
@@ -142,11 +182,19 @@ export const Gdpr: FC<GdprProps> & BlockConfigs = () => {
 
 			return { ...cat, enabled };
 		});
-	}, []);
+	}, [gdprConfigs.categories]);
+
+	const impressionTracked = useRef(false);
 
 	useEffect(() => {
 		const hasCookies = Cookies.get(`${COOKIE_NAME}_banner`) === 'dismiss';
 		setBannerDismissed(hasCookies);
+
+		// Track impression when the banner is shown
+		if (!hasCookies && !impressionTracked.current) {
+			trackCookieEvent('impression');
+			impressionTracked.current = true;
+		}
 
 		window.addEventListener('hashchange', onHashChange);
 
@@ -159,7 +207,55 @@ export const Gdpr: FC<GdprProps> & BlockConfigs = () => {
 	useEffect(() => {
 		const cats = getCategoriesSettings();
 		setCategories(cats);
-	}, [locale, getCategoriesSettings]);
+	}, [getCategoriesSettings, locale]);
+
+	useEffect(() => {
+		if (typeof window === 'undefined') return;
+
+		window.dataLayer = window.dataLayer || [];
+		function gtag() {
+			window.dataLayer?.push(arguments);
+		}
+
+		window.gtag = window.gtag || gtag;
+
+		// Consent Mode v2 default state (before choice)
+		sendGTMEvent({
+			event: 'consent',
+			value: 'default',
+			parameters: {
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+				analytics_storage: 'denied',
+			},
+		});
+	}, []);
+
+	const initializeGTMConsent = useRef(false);
+
+	useEffect(() => {
+		if (initializeGTMConsent.current) return;
+
+		//  Wait until googletagmanager is loaded
+		if (!process.env.NEXT_PUBLIC_GTM_KEY) return;
+
+		// Wait until the services are loaded
+		if (Object.keys(gdprServices).length === 0) return;
+
+		initializeGTMConsent.current = true;
+
+		// Return if the user has not dismissed the banner yet
+		const hasCookies = Cookies.get(`${COOKIE_NAME}_banner`) === 'dismiss';
+		if (!hasCookies) return;
+
+		// Initialize GTM consent with the saved in cookies categories state
+		updateGTMConsent(gdprServices.gtm?.isAccepted ?? false);
+	}, [gdprServices, process.env.NEXT_PUBLIC_GTM_KEY, updateGTMConsent]);
+
+	// ##############################
+	// #endregion
+	// ##############################
 
 	return (
 		<>
@@ -178,19 +274,8 @@ export const Gdpr: FC<GdprProps> & BlockConfigs = () => {
 					onModalClosed={onModalClosed}
 				/>
 			</div>
-			{gdprServices?.gtm ? (
-				<>
-					<Script
-						id="gtm-script"
-						dangerouslySetInnerHTML={{
-							__html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-	})(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_KEY}');`,
-						}}
-					/>
-				</>
+			{gdprServices?.gtm && process.env.NEXT_PUBLIC_GTM_KEY ? (
+				<GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_KEY} />
 			) : null}
 		</>
 	);

--- a/wordpress/.gitignore
+++ b/wordpress/.gitignore
@@ -9,3 +9,6 @@ auth.json
 !/plugins
 /plugins/*
 !/plugins/.gitkeep
+
+## keep google analytics plugin
+!/plugins/cookie-analytics

--- a/wordpress/plugins/cookie-analytics/assets/admin.css
+++ b/wordpress/plugins/cookie-analytics/assets/admin.css
@@ -1,0 +1,209 @@
+/* Cookie Analytics Admin Styles */
+
+.cookie-analytics-wrap {
+	max-width: 1100px;
+}
+
+/* Card layout */
+.cookie-analytics-card {
+	background: #fff;
+	border: 1px solid #ccd0d4;
+	border-radius: 4px;
+	padding: 20px 24px;
+	margin: 20px 0;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+.cookie-analytics-card h2 {
+	margin-top: 0;
+	padding: 0;
+	font-size: 1.2em;
+	border-bottom: 1px solid #eee;
+	padding-bottom: 10px;
+	margin-bottom: 15px;
+}
+
+/* Date filter */
+.cookie-analytics-date-filter {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+.cookie-analytics-date-filter label {
+	font-weight: 600;
+}
+
+.cookie-analytics-date-filter input[type="date"] {
+	padding: 4px 8px;
+	min-width: 160px;
+}
+
+.cookie-analytics-date-label {
+	margin-top: 10px;
+	color: #666;
+}
+
+/* Export button */
+.cookie-analytics-export-button {
+	display: inline-flex !important;
+	align-items: center;
+}
+
+/* Chart */
+.cookie-analytics-chart-container {
+	position: relative;
+	width: 100%;
+	max-height: 400px;
+}
+
+/* Stats table */
+.cookie-analytics-table {
+	border-collapse: collapse;
+}
+
+.cookie-analytics-table th {
+	text-align: left;
+	background: #f9f9f9;
+}
+
+.cookie-analytics-table td,
+.cookie-analytics-table th {
+	padding: 10px 12px;
+}
+
+.cookie-analytics-table tfoot td {
+	background: #f6f7f7;
+	font-size: 0.95em;
+}
+
+/* Color dots */
+.cookie-analytics-dot {
+	display: inline-block;
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	margin-right: 6px;
+	vertical-align: middle;
+}
+
+.dot-impression {
+	background-color: #3b82f6;
+}
+
+.dot-accept {
+	background-color: #22c55e;
+}
+
+.dot-reject {
+	background-color: #ef4444;
+}
+
+.dot-personalize {
+	background-color: #f59e0b;
+}
+
+/* Rates */
+.cookie-analytics-rate {
+	font-weight: 600;
+	padding: 2px 8px;
+	border-radius: 10px;
+	font-size: 0.9em;
+}
+
+.rate-accept {
+	background: #dcfce7;
+	color: #166534;
+}
+
+.rate-reject {
+	background: #fee2e2;
+	color: #991b1b;
+}
+
+/* Blacklist form */
+.cookie-analytics-blacklist-form {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-top: 12px;
+}
+
+.cookie-analytics-blacklist-form input[type="text"] {
+	min-width: 220px;
+	padding: 4px 8px;
+}
+
+/* Empty state */
+.cookie-analytics-empty {
+	color: #999;
+	font-style: italic;
+}
+
+/* Danger Zone */
+.cookie-analytics-danger-zone {
+	border-color: #dc3232;
+	background: #fff8f8;
+}
+
+.cookie-analytics-danger-zone h2 {
+	color: #dc3232;
+	border-bottom-color: #f5c6c6;
+}
+
+.cookie-analytics-danger-section h3 {
+	margin: 0 0 4px;
+	font-size: 1em;
+}
+
+.cookie-analytics-danger-divider {
+	border: none;
+	border-top: 1px solid #f5c6c6;
+	margin: 20px 0;
+}
+
+.cookie-analytics-retention-form {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-top: 12px;
+	flex-wrap: wrap;
+}
+
+.cookie-analytics-retention-form label {
+	font-weight: 600;
+}
+
+.cookie-analytics-retention-form select {
+	min-width: 200px;
+}
+
+.cookie-analytics-danger-form {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-top: 12px;
+	flex-wrap: wrap;
+}
+
+.cookie-analytics-danger-form label {
+	font-weight: 600;
+}
+
+.cookie-analytics-danger-form input[type="text"] {
+	max-width: 160px;
+	padding: 4px 8px;
+}
+
+.cookie-analytics-delete-button {
+	background: #dc3232 !important;
+	border-color: #b52727 !important;
+	color: #fff !important;
+}
+
+.cookie-analytics-delete-button:hover {
+	background: #b52727 !important;
+	border-color: #8e1e1e !important;
+	color: #fff !important;
+}

--- a/wordpress/plugins/cookie-analytics/assets/admin.js
+++ b/wordpress/plugins/cookie-analytics/assets/admin.js
@@ -1,0 +1,96 @@
+(function () {
+	'use strict';
+
+	var data = window.cookieAnalyticsData;
+
+	if (!data || !data.labels || data.labels.length === 0) {
+		return;
+	}
+
+	var canvas = document.getElementById('cookieAnalyticsChart');
+	if (!canvas) return;
+
+	new Chart(canvas, {
+		type: 'line',
+		data: {
+			labels: data.labels,
+			datasets: [
+				{
+					label: 'Impressions',
+					data: data.impressions,
+					borderColor: '#3b82f6',
+					backgroundColor: 'rgba(59, 130, 246, 0.1)',
+					borderWidth: 2,
+					tension: 0.3,
+					fill: true,
+				},
+				{
+					label: 'Accepts',
+					data: data.accepts,
+					borderColor: '#22c55e',
+					backgroundColor: 'rgba(34, 197, 94, 0.1)',
+					borderWidth: 2,
+					tension: 0.3,
+					fill: true,
+				},
+				{
+					label: 'Rejects',
+					data: data.rejects,
+					borderColor: '#ef4444',
+					backgroundColor: 'rgba(239, 68, 68, 0.1)',
+					borderWidth: 2,
+					tension: 0.3,
+					fill: true,
+				},
+				{
+					label: 'Personalize',
+					data: data.personalizes,
+					borderColor: '#f59e0b',
+					backgroundColor: 'rgba(245, 158, 11, 0.1)',
+					borderWidth: 2,
+					tension: 0.3,
+					fill: true,
+				},
+			],
+		},
+		options: {
+			responsive: true,
+			maintainAspectRatio: true,
+			interaction: {
+				mode: 'index',
+				intersect: false,
+			},
+			plugins: {
+				legend: {
+					position: 'bottom',
+					labels: {
+						usePointStyle: true,
+						pointStyle: 'circle',
+						padding: 20,
+					},
+				},
+				tooltip: {
+					backgroundColor: 'rgba(0, 0, 0, 0.8)',
+					cornerRadius: 6,
+					padding: 12,
+				},
+			},
+			scales: {
+				y: {
+					beginAtZero: true,
+					ticks: {
+						precision: 0,
+					},
+					grid: {
+						color: 'rgba(0, 0, 0, 0.06)',
+					},
+				},
+				x: {
+					grid: {
+						display: false,
+					},
+				},
+			},
+		},
+	});
+})();

--- a/wordpress/plugins/cookie-analytics/cookie-analytics.php
+++ b/wordpress/plugins/cookie-analytics/cookie-analytics.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Plugin Name: Cookie Analytics
+ * Description: Track and analyze GDPR cookie banner interactions (impressions, accepts, rejects, personalizations).
+ * Version: 1.0.0
+ * Author: Superstack
+ * Text Domain: cookie-analytics
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'COOKIE_ANALYTICS_VERSION', '1.0.0' );
+define( 'COOKIE_ANALYTICS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'COOKIE_ANALYTICS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+// Includes
+require_once COOKIE_ANALYTICS_PLUGIN_DIR . 'includes/class-cookie-analytics-db.php';
+require_once COOKIE_ANALYTICS_PLUGIN_DIR . 'includes/class-cookie-analytics-api.php';
+require_once COOKIE_ANALYTICS_PLUGIN_DIR . 'includes/class-cookie-analytics-admin.php';
+
+/**
+ * Activation hook: create database tables and schedule cleanup.
+ */
+function cookie_analytics_activate() {
+	Cookie_Analytics_DB::create_tables();
+	if ( ! wp_next_scheduled( 'cookie_analytics_daily_cleanup' ) ) {
+		wp_schedule_event( time(), 'daily', 'cookie_analytics_daily_cleanup' );
+	}
+}
+register_activation_hook( __FILE__, 'cookie_analytics_activate' );
+
+/**
+ * Deactivation hook: clear scheduled cleanup.
+ */
+function cookie_analytics_deactivate() {
+	wp_clear_scheduled_hook( 'cookie_analytics_daily_cleanup' );
+}
+register_deactivation_hook( __FILE__, 'cookie_analytics_deactivate' );
+
+/**
+ * Daily cleanup: delete events older than the retention period.
+ */
+function cookie_analytics_run_cleanup() {
+	$days = Cookie_Analytics_DB::get_retention_days();
+	if ( $days > 0 ) {
+		Cookie_Analytics_DB::delete_events_older_than( $days );
+	}
+}
+add_action( 'cookie_analytics_daily_cleanup', 'cookie_analytics_run_cleanup' );
+
+/**
+ * Initialize plugin components.
+ */
+function cookie_analytics_init() {
+	new Cookie_Analytics_API();
+	if ( is_admin() ) {
+		new Cookie_Analytics_Admin();
+	}
+}
+add_action( 'plugins_loaded', 'cookie_analytics_init' );

--- a/wordpress/plugins/cookie-analytics/includes/class-cookie-analytics-admin.php
+++ b/wordpress/plugins/cookie-analytics/includes/class-cookie-analytics-admin.php
@@ -1,0 +1,523 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Cookie_Analytics_Admin {
+
+	public function __construct() {
+		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		add_action( 'admin_init', [ $this, 'handle_blacklist_actions' ] );
+		add_action( 'admin_init', [ $this, 'handle_danger_zone_actions' ] );
+		add_action( 'admin_init', [ $this, 'handle_retention_settings' ] );
+		add_action( 'admin_init', [ $this, 'handle_csv_export' ] );
+	}
+
+	/**
+	 * Register the top-level admin menu page.
+	 */
+	public function add_admin_menu() {
+		add_menu_page(
+			__( 'Cookie Analytics', 'cookie-analytics' ),
+			__( 'Cookie Analytics', 'cookie-analytics' ),
+			'manage_options',
+			'cookie-analytics',
+			[ $this, 'render_page' ],
+			'dashicons-chart-bar',
+			30
+		);
+	}
+
+	/**
+	 * Enqueue admin styles and Chart.js on our admin page only.
+	 */
+	public function enqueue_assets( $hook ) {
+		if ( 'toplevel_page_cookie-analytics' !== $hook ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'cookie-analytics-admin',
+			COOKIE_ANALYTICS_PLUGIN_URL . 'assets/admin.css',
+			[],
+			COOKIE_ANALYTICS_VERSION
+		);
+
+		wp_enqueue_script(
+			'chartjs',
+			'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js',
+			[],
+			'4.4.0',
+			true
+		);
+
+		wp_enqueue_script(
+			'cookie-analytics-admin',
+			COOKIE_ANALYTICS_PLUGIN_URL . 'assets/admin.js',
+			[ 'chartjs' ],
+			COOKIE_ANALYTICS_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Handle blacklist add/remove form submissions.
+	 */
+	public function handle_blacklist_actions() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Add IP to blacklist
+		if (
+			isset( $_POST['cookie_analytics_add_ip'] ) &&
+			wp_verify_nonce( $_POST['_wpnonce_blacklist'], 'cookie_analytics_blacklist' )
+		) {
+			$ip = sanitize_text_field( $_POST['blacklist_ip'] ?? '' );
+			if ( $ip ) {
+				$result = Cookie_Analytics_DB::add_to_blacklist( $ip );
+				if ( false === $result ) {
+					add_settings_error( 'cookie-analytics', 'invalid-ip', __( 'Invalid IP address.', 'cookie-analytics' ), 'error' );
+				} else {
+					add_settings_error( 'cookie-analytics', 'ip-added', __( 'IP address added to blacklist.', 'cookie-analytics' ), 'success' );
+				}
+			}
+		}
+
+		// Remove IP from blacklist
+		if (
+			isset( $_GET['action'] ) && $_GET['action'] === 'remove_ip' &&
+			isset( $_GET['id'] ) &&
+			wp_verify_nonce( $_GET['_wpnonce'], 'remove_ip_' . $_GET['id'] )
+		) {
+			Cookie_Analytics_DB::remove_from_blacklist( (int) $_GET['id'] );
+			wp_redirect( admin_url( 'admin.php?page=cookie-analytics' ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Handle danger zone form submissions (delete all data).
+	 */
+	public function handle_danger_zone_actions() {
+		if (
+			isset( $_POST['cookie_analytics_delete_all'] ) &&
+			wp_verify_nonce( $_POST['_wpnonce_danger_zone'], 'cookie_analytics_danger_zone' )
+		) {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
+
+			$confirm = sanitize_text_field( $_POST['confirm_delete'] ?? '' );
+			if ( 'DELETE' !== $confirm ) {
+				add_settings_error( 'cookie-analytics', 'delete-not-confirmed', __( 'You must type DELETE to confirm.', 'cookie-analytics' ), 'error' );
+				return;
+			}
+
+			$result = Cookie_Analytics_DB::truncate_events();
+			if ( $result ) {
+				add_settings_error( 'cookie-analytics', 'data-deleted', __( 'All analytics data has been deleted.', 'cookie-analytics' ), 'success' );
+			} else {
+				add_settings_error( 'cookie-analytics', 'delete-failed', __( 'Failed to delete analytics data.', 'cookie-analytics' ), 'error' );
+			}
+		}
+	}
+
+	/**
+	 * Handle retention settings form submission.
+	 */
+	public function handle_retention_settings() {
+		if (
+			isset( $_POST['cookie_analytics_save_retention'] ) &&
+			wp_verify_nonce( $_POST['_wpnonce_retention'], 'cookie_analytics_retention' )
+		) {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
+
+			$days = isset( $_POST['retention_days'] ) ? absint( $_POST['retention_days'] ) : 0;
+			Cookie_Analytics_DB::set_retention_days( $days );
+
+			// If retention is set, run an immediate cleanup
+			if ( $days > 0 ) {
+				$deleted = Cookie_Analytics_DB::delete_events_older_than( $days );
+				add_settings_error(
+					'cookie-analytics',
+					'retention-saved',
+					sprintf(
+						/* translators: 1: retention days, 2: number of deleted rows */
+						__( 'Retention set to %1$d days. %2$d old record(s) cleaned up.', 'cookie-analytics' ),
+						$days,
+						max( 0, (int) $deleted )
+					),
+					'success'
+				);
+			} else {
+				add_settings_error( 'cookie-analytics', 'retention-saved', __( 'Retention set to keep all data.', 'cookie-analytics' ), 'success' );
+			}
+
+			// Ensure cron is scheduled
+			if ( ! wp_next_scheduled( 'cookie_analytics_daily_cleanup' ) ) {
+				wp_schedule_event( time(), 'daily', 'cookie_analytics_daily_cleanup' );
+			}
+		}
+	}
+
+	/**
+	 * Handle CSV export. Must run before any HTML output.
+	 */
+	public function handle_csv_export() {
+		if (
+			! isset( $_GET['action'] ) ||
+			'export_csv' !== $_GET['action'] ||
+			! isset( $_GET['page'] ) ||
+			'cookie-analytics' !== $_GET['page']
+		) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'cookie_analytics_export_csv' ) ) {
+			wp_die( __( 'Invalid nonce.', 'cookie-analytics' ) );
+		}
+
+		// Get date filters
+		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( $_GET['start_date'] ) : null;
+		$end_date   = isset( $_GET['end_date'] ) ? sanitize_text_field( $_GET['end_date'] ) : null;
+
+		if ( $start_date && ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $start_date ) ) {
+			$start_date = null;
+		}
+		if ( $end_date && ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $end_date ) ) {
+			$end_date = null;
+		}
+
+		$daily  = Cookie_Analytics_DB::get_daily_counts( $start_date, $end_date );
+		$counts = Cookie_Analytics_DB::get_event_counts( $start_date, $end_date );
+
+		// Build filename
+		$filename = 'cookie-analytics';
+		if ( $start_date ) {
+			$filename .= '-from-' . $start_date;
+		}
+		if ( $end_date ) {
+			$filename .= '-to-' . $end_date;
+		}
+		$filename .= '.csv';
+
+		// Send headers
+		header( 'Content-Type: text/csv; charset=utf-8' );
+		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+		header( 'Pragma: no-cache' );
+		header( 'Expires: 0' );
+
+		$output = fopen( 'php://output', 'w' );
+
+		// Header row
+		fputcsv( $output, [ 'Date', 'Impressions', 'Accepts', 'Rejects', 'Personalize', 'Acceptance Rate (%)', 'Rejection Rate (%)' ] );
+
+		// Daily rows
+		foreach ( $daily as $date => $day_counts ) {
+			$imp = max( $day_counts['impression'], 1 );
+			fputcsv( $output, [
+				$date,
+				$day_counts['impression'],
+				$day_counts['accept'],
+				$day_counts['reject'],
+				$day_counts['personalize'],
+				round( ( $day_counts['accept'] / $imp ) * 100, 1 ),
+				round( ( $day_counts['reject'] / $imp ) * 100, 1 ),
+			] );
+		}
+
+		// Totals row
+		$total_imp = max( $counts['impression'], 1 );
+		fputcsv( $output, [
+			'TOTAL',
+			$counts['impression'],
+			$counts['accept'],
+			$counts['reject'],
+			$counts['personalize'],
+			round( ( $counts['accept'] / $total_imp ) * 100, 1 ),
+			round( ( $counts['reject'] / $total_imp ) * 100, 1 ),
+		] );
+
+		fclose( $output );
+		exit;
+	}
+
+	/**
+	 * Render the admin page.
+	 */
+	public function render_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Get date filters
+		$start_date = isset( $_GET['start_date'] ) ? sanitize_text_field( $_GET['start_date'] ) : null;
+		$end_date   = isset( $_GET['end_date'] ) ? sanitize_text_field( $_GET['end_date'] ) : null;
+
+		// Validate dates
+		if ( $start_date && ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $start_date ) ) {
+			$start_date = null;
+		}
+		if ( $end_date && ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $end_date ) ) {
+			$end_date = null;
+		}
+
+		// Get data
+		$counts = Cookie_Analytics_DB::get_event_counts( $start_date, $end_date );
+		$daily  = Cookie_Analytics_DB::get_daily_counts( $start_date, $end_date );
+
+		// Calculate rates
+		$total_impressions = max( $counts['impression'], 1 ); // Avoid division by zero
+		$acceptance_rate   = round( ( $counts['accept'] / $total_impressions ) * 100, 1 );
+		$rejection_rate    = round( ( $counts['reject'] / $total_impressions ) * 100, 1 );
+
+		// Prepare chart data
+		$chart_labels = array_keys( $daily );
+		$chart_data   = [
+			'impression'  => [],
+			'accept'      => [],
+			'reject'      => [],
+			'personalize' => [],
+		];
+		foreach ( $daily as $date => $day_counts ) {
+			$chart_data['impression'][]  = $day_counts['impression'];
+			$chart_data['accept'][]      = $day_counts['accept'];
+			$chart_data['reject'][]      = $day_counts['reject'];
+			$chart_data['personalize'][] = $day_counts['personalize'];
+		}
+
+		// Get blacklist
+		$blacklist = Cookie_Analytics_DB::get_blacklist();
+
+		// Date range label
+		$date_label = __( 'All time', 'cookie-analytics' );
+		if ( $start_date && $end_date ) {
+			$date_label = sprintf( '%s &ndash; %s', esc_html( $start_date ), esc_html( $end_date ) );
+		} elseif ( $start_date ) {
+			$date_label = sprintf( __( 'From %s', 'cookie-analytics' ), esc_html( $start_date ) );
+		} elseif ( $end_date ) {
+			$date_label = sprintf( __( 'Until %s', 'cookie-analytics' ), esc_html( $end_date ) );
+		}
+
+		?>
+		<div class="wrap cookie-analytics-wrap">
+			<h1><?php esc_html_e( 'Cookie Analytics', 'cookie-analytics' ); ?></h1>
+
+			<?php settings_errors( 'cookie-analytics' ); ?>
+
+			<!-- Date Range Filter -->
+			<div class="cookie-analytics-card">
+				<h2><?php esc_html_e( 'Date Range', 'cookie-analytics' ); ?></h2>
+				<form method="get" class="cookie-analytics-date-filter">
+					<input type="hidden" name="page" value="cookie-analytics" />
+					<label for="start_date"><?php esc_html_e( 'From:', 'cookie-analytics' ); ?></label>
+					<input type="date" id="start_date" name="start_date" value="<?php echo esc_attr( $start_date ?? '' ); ?>" />
+
+					<label for="end_date"><?php esc_html_e( 'To:', 'cookie-analytics' ); ?></label>
+					<input type="date" id="end_date" name="end_date" value="<?php echo esc_attr( $end_date ?? '' ); ?>" />
+
+					<button type="submit" class="button button-primary"><?php esc_html_e( 'Filter', 'cookie-analytics' ); ?></button>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=cookie-analytics' ) ); ?>" class="button"><?php esc_html_e( 'Reset', 'cookie-analytics' ); ?></a>
+					<?php
+					$export_url = wp_nonce_url(
+						add_query_arg(
+							array_filter( [
+								'page'       => 'cookie-analytics',
+								'action'     => 'export_csv',
+								'start_date' => $start_date,
+								'end_date'   => $end_date,
+							] ),
+							admin_url( 'admin.php' )
+						),
+						'cookie_analytics_export_csv'
+					);
+					?>
+					<a href="<?php echo esc_url( $export_url ); ?>" class="button cookie-analytics-export-button">
+						<span class="dashicons dashicons-download" style="vertical-align: middle; margin-right: 2px;"></span>
+						<?php esc_html_e( 'Export CSV', 'cookie-analytics' ); ?>
+					</a>
+				</form>
+				<p class="cookie-analytics-date-label">
+					<?php
+					/* translators: %s: date range label */
+					printf( esc_html__( 'Showing data for: %s', 'cookie-analytics' ), '<strong>' . $date_label . '</strong>' );
+					?>
+				</p>
+			</div>
+
+			<!-- Chart -->
+			<div class="cookie-analytics-card">
+				<h2><?php esc_html_e( 'Events Over Time', 'cookie-analytics' ); ?></h2>
+				<?php if ( empty( $daily ) ) : ?>
+					<p class="cookie-analytics-empty"><?php esc_html_e( 'No data available for the selected period.', 'cookie-analytics' ); ?></p>
+				<?php else : ?>
+					<div class="cookie-analytics-chart-container">
+						<canvas id="cookieAnalyticsChart"></canvas>
+					</div>
+				<?php endif; ?>
+			</div>
+
+			<!-- Stats Table -->
+			<div class="cookie-analytics-card">
+				<h2><?php esc_html_e( 'Statistics', 'cookie-analytics' ); ?></h2>
+				<table class="widefat cookie-analytics-table">
+					<thead>
+						<tr>
+							<th><?php esc_html_e( 'Event Type', 'cookie-analytics' ); ?></th>
+							<th><?php esc_html_e( 'Count', 'cookie-analytics' ); ?></th>
+							<th><?php esc_html_e( 'Rate (vs Impressions)', 'cookie-analytics' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><span class="cookie-analytics-dot dot-impression"></span> <?php esc_html_e( 'Impressions', 'cookie-analytics' ); ?></td>
+							<td><strong><?php echo esc_html( number_format_i18n( $counts['impression'] ) ); ?></strong></td>
+							<td>&mdash;</td>
+						</tr>
+						<tr>
+							<td><span class="cookie-analytics-dot dot-accept"></span> <?php esc_html_e( 'Accepts', 'cookie-analytics' ); ?></td>
+							<td><strong><?php echo esc_html( number_format_i18n( $counts['accept'] ) ); ?></strong></td>
+							<td>
+								<span class="cookie-analytics-rate rate-accept"><?php echo esc_html( $acceptance_rate ); ?>%</span>
+							</td>
+						</tr>
+						<tr>
+							<td><span class="cookie-analytics-dot dot-reject"></span> <?php esc_html_e( 'Rejects', 'cookie-analytics' ); ?></td>
+							<td><strong><?php echo esc_html( number_format_i18n( $counts['reject'] ) ); ?></strong></td>
+							<td>
+								<span class="cookie-analytics-rate rate-reject"><?php echo esc_html( $rejection_rate ); ?>%</span>
+							</td>
+						</tr>
+						<tr>
+							<td><span class="cookie-analytics-dot dot-personalize"></span> <?php esc_html_e( 'Personalize', 'cookie-analytics' ); ?></td>
+							<td><strong><?php echo esc_html( number_format_i18n( $counts['personalize'] ) ); ?></strong></td>
+							<td>
+								<span class="cookie-analytics-rate"><?php echo esc_html( round( ( $counts['personalize'] / $total_impressions ) * 100, 1 ) ); ?>%</span>
+							</td>
+						</tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td colspan="3">
+								<strong><?php esc_html_e( 'Acceptance Rate:', 'cookie-analytics' ); ?></strong> <?php echo esc_html( $acceptance_rate ); ?>%
+								&nbsp;&nbsp;|&nbsp;&nbsp;
+								<strong><?php esc_html_e( 'Rejection Rate:', 'cookie-analytics' ); ?></strong> <?php echo esc_html( $rejection_rate ); ?>%
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+
+			<!-- IP Blacklist -->
+			<div class="cookie-analytics-card">
+				<h2><?php esc_html_e( 'IP Blacklist', 'cookie-analytics' ); ?></h2>
+				<p class="description"><?php esc_html_e( 'Events from blacklisted IP addresses will not be recorded. Use this to exclude your own traffic or known bots.', 'cookie-analytics' ); ?></p>
+
+				<form method="post" class="cookie-analytics-blacklist-form">
+					<?php wp_nonce_field( 'cookie_analytics_blacklist', '_wpnonce_blacklist' ); ?>
+					<input type="text" name="blacklist_ip" placeholder="<?php esc_attr_e( 'e.g. 192.168.1.1', 'cookie-analytics' ); ?>" required />
+					<button type="submit" name="cookie_analytics_add_ip" class="button button-primary"><?php esc_html_e( 'Add IP', 'cookie-analytics' ); ?></button>
+				</form>
+
+				<?php if ( ! empty( $blacklist ) ) : ?>
+					<table class="widefat cookie-analytics-table" style="margin-top: 15px;">
+						<thead>
+							<tr>
+								<th><?php esc_html_e( 'IP Address', 'cookie-analytics' ); ?></th>
+								<th><?php esc_html_e( 'Added On', 'cookie-analytics' ); ?></th>
+								<th><?php esc_html_e( 'Actions', 'cookie-analytics' ); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ( $blacklist as $entry ) : ?>
+								<tr>
+									<td><code><?php echo esc_html( $entry['ip_address'] ); ?></code></td>
+									<td><?php echo esc_html( $entry['created_at'] ); ?></td>
+									<td>
+										<a
+											href="<?php echo esc_url( wp_nonce_url(
+												admin_url( 'admin.php?page=cookie-analytics&action=remove_ip&id=' . $entry['id'] ),
+												'remove_ip_' . $entry['id']
+											) ); ?>"
+											class="button button-small button-link-delete"
+											onclick="return confirm('<?php esc_attr_e( 'Remove this IP from the blacklist?', 'cookie-analytics' ); ?>');"
+										>
+											<?php esc_html_e( 'Remove', 'cookie-analytics' ); ?>
+										</a>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				<?php else : ?>
+					<p class="cookie-analytics-empty" style="margin-top: 15px;"><?php esc_html_e( 'No IPs in the blacklist.', 'cookie-analytics' ); ?></p>
+				<?php endif; ?>
+			</div>
+
+			<!-- Danger Zone -->
+			<div class="cookie-analytics-card cookie-analytics-danger-zone">
+				<h2><?php esc_html_e( 'Danger Zone', 'cookie-analytics' ); ?></h2>
+
+				<!-- Retention Setting -->
+				<div class="cookie-analytics-danger-section">
+					<h3><?php esc_html_e( 'Data Retention', 'cookie-analytics' ); ?></h3>
+					<p class="description"><?php esc_html_e( 'Automatically delete event data older than the specified period. A daily cleanup runs in the background.', 'cookie-analytics' ); ?></p>
+
+					<?php $retention_days = Cookie_Analytics_DB::get_retention_days(); ?>
+					<form method="post" class="cookie-analytics-retention-form">
+						<?php wp_nonce_field( 'cookie_analytics_retention', '_wpnonce_retention' ); ?>
+						<label for="retention_days"><?php esc_html_e( 'Keep data for:', 'cookie-analytics' ); ?></label>
+						<select id="retention_days" name="retention_days">
+							<option value="0" <?php selected( $retention_days, 0 ); ?>><?php esc_html_e( 'Forever (no auto-delete)', 'cookie-analytics' ); ?></option>
+							<option value="30" <?php selected( $retention_days, 30 ); ?>><?php esc_html_e( '30 days', 'cookie-analytics' ); ?></option>
+							<option value="60" <?php selected( $retention_days, 60 ); ?>><?php esc_html_e( '60 days', 'cookie-analytics' ); ?></option>
+							<option value="90" <?php selected( $retention_days, 90 ); ?>><?php esc_html_e( '90 days', 'cookie-analytics' ); ?></option>
+							<option value="180" <?php selected( $retention_days, 180 ); ?>><?php esc_html_e( '6 months', 'cookie-analytics' ); ?></option>
+							<option value="365" <?php selected( $retention_days, 365 ); ?>><?php esc_html_e( '1 year', 'cookie-analytics' ); ?></option>
+						</select>
+						<button type="submit" name="cookie_analytics_save_retention" class="button"><?php esc_html_e( 'Save', 'cookie-analytics' ); ?></button>
+					</form>
+				</div>
+
+				<hr class="cookie-analytics-danger-divider" />
+
+				<!-- Delete All Data -->
+				<div class="cookie-analytics-danger-section">
+					<h3><?php esc_html_e( 'Delete All Data', 'cookie-analytics' ); ?></h3>
+					<p class="description"><?php esc_html_e( 'Permanently delete all cookie analytics event data. This action cannot be undone.', 'cookie-analytics' ); ?></p>
+
+					<form method="post" class="cookie-analytics-danger-form">
+						<?php wp_nonce_field( 'cookie_analytics_danger_zone', '_wpnonce_danger_zone' ); ?>
+						<label for="confirm_delete">
+							<?php esc_html_e( 'Type DELETE to confirm:', 'cookie-analytics' ); ?>
+						</label>
+						<input type="text" id="confirm_delete" name="confirm_delete" placeholder="DELETE" autocomplete="off" required />
+						<button type="submit" name="cookie_analytics_delete_all" class="button cookie-analytics-delete-button" onclick="return confirm('<?php esc_attr_e( 'Are you sure? All analytics data will be permanently deleted.', 'cookie-analytics' ); ?>');">
+							<?php esc_html_e( 'Delete All Data', 'cookie-analytics' ); ?>
+						</button>
+					</form>
+				</div>
+			</div>
+		</div>
+
+		<script>
+			window.cookieAnalyticsData = {
+				labels: <?php echo wp_json_encode( $chart_labels ); ?>,
+				impressions: <?php echo wp_json_encode( $chart_data['impression'] ); ?>,
+				accepts: <?php echo wp_json_encode( $chart_data['accept'] ); ?>,
+				rejects: <?php echo wp_json_encode( $chart_data['reject'] ); ?>,
+				personalizes: <?php echo wp_json_encode( $chart_data['personalize'] ); ?>,
+			};
+		</script>
+		<?php
+	}
+}

--- a/wordpress/plugins/cookie-analytics/includes/class-cookie-analytics-api.php
+++ b/wordpress/plugins/cookie-analytics/includes/class-cookie-analytics-api.php
@@ -1,0 +1,197 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Cookie_Analytics_API {
+
+	public function __construct() {
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route( 'supt/v1', '/cookie-stats', [
+			'methods'             => 'POST',
+			'callback'            => [ $this, 'record_event' ],
+			'permission_callback' => '__return_true', // Public endpoint
+			'args'                => [
+				'event_type' => [
+					'required'          => true,
+					'type'              => 'string',
+					'enum'              => [ 'impression', 'accept', 'reject', 'personalize' ],
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			],
+		] );
+	}
+
+	/**
+	 * Known bot User-Agent patterns (case-insensitive substrings).
+	 */
+	private const BOT_PATTERNS = [
+		'bot',
+		'crawl',
+		'spider',
+		'slurp',
+		'googlebot',
+		'bingbot',
+		'yandexbot',
+		'baiduspider',
+		'duckduckbot',
+		'facebookexternalhit',
+		'facebot',
+		'ia_archiver',
+		'semrushbot',
+		'ahrefsbot',
+		'dotbot',
+		'rogerbot',
+		'linkedinbot',
+		'embedly',
+		'quora link preview',
+		'showyoubot',
+		'outbrain',
+		'pinterest',
+		'applebot',
+		'twitterbot',
+		'whatsapp',
+		'telegrambot',
+		'screaming frog',
+		'lighthouse',
+		'chrome-lighthouse',
+		'pagespeed',
+		'headlesschrome',
+		'phantomjs',
+		'prerender',
+		'wget',
+		'curl',
+		'python-requests',
+		'go-http-client',
+		'apache-httpclient',
+		'http_request',
+		'node-fetch',
+		'axios',
+		'uptimerobot',
+		'pingdom',
+		'statuscake',
+		'gptbot',
+		'chatgpt',
+		'claudebot',
+		'anthropic',
+		'bytespider',
+		'petalbot',
+		'mj12bot',
+	];
+
+	/**
+	 * Handle incoming event tracking requests.
+	 *
+	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response
+	 */
+	public function record_event( $request ) {
+		$event_type = $request->get_param( 'event_type' );
+
+		// Bot detection: skip known bots
+		if ( $this->is_bot( $request ) ) {
+			return new WP_REST_Response( [ 'success' => true, 'skipped' => true ], 200 );
+		}
+
+		$ip = $this->get_visitor_ip( $request );
+
+		// Check IP blacklist
+		if ( $ip && Cookie_Analytics_DB::is_ip_blacklisted( $ip ) ) {
+			return new WP_REST_Response( [ 'success' => true, 'skipped' => true ], 200 );
+		}
+
+		$result = Cookie_Analytics_DB::insert_event( $event_type );
+
+		if ( false === $result ) {
+			return new WP_REST_Response(
+				[ 'success' => false, 'message' => 'Invalid event type.' ],
+				400
+			);
+		}
+
+		return new WP_REST_Response( [ 'success' => true ], 200 );
+	}
+
+	/**
+	 * Detect if the request comes from a known bot based on User-Agent.
+	 *
+	 * @param WP_REST_Request $request
+	 * @return bool True if the request is from a bot.
+	 */
+	private function is_bot( $request ) {
+		$ua = $request->get_header( 'User-Agent' );
+
+		// No User-Agent at all is suspicious — likely a script/bot
+		if ( empty( $ua ) ) {
+			return true;
+		}
+
+		$ua_lower = strtolower( $ua );
+
+		foreach ( self::BOT_PATTERNS as $pattern ) {
+			if ( strpos( $ua_lower, $pattern ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the real visitor IP address.
+	 * Checks multiple headers in priority order to support various
+	 * proxy setups (Next.js proxy, nginx, Docker, load balancers).
+	 *
+	 * @param WP_REST_Request $request
+	 * @return string|null
+	 */
+	private function get_visitor_ip( $request ) {
+		// Headers to check, in priority order
+		$headers = [
+			'X-Forwarded-For',      // Standard proxy header (Next.js proxy, nginx, etc.)
+			'X-Real-Ip',            // nginx real IP
+			'CF-Connecting-IP',     // Cloudflare
+			'True-Client-IP',       // Akamai / Cloudflare Enterprise
+			'X-Client-IP',          // Some load balancers
+		];
+
+		foreach ( $headers as $header ) {
+			$value = $request->get_header( $header );
+			if ( ! empty( $value ) ) {
+				// X-Forwarded-For can contain multiple IPs; first is the client
+				$ip = trim( explode( ',', $value )[0] );
+				if ( $ip ) {
+					return $ip;
+				}
+			}
+		}
+
+		// Also check $_SERVER directly for headers that WP_REST_Request may not expose
+		$server_headers = [
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_X_REAL_IP',
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_TRUE_CLIENT_IP',
+			'HTTP_X_CLIENT_IP',
+		];
+
+		foreach ( $server_headers as $header ) {
+			if ( ! empty( $_SERVER[ $header ] ) ) {
+				$ip = trim( explode( ',', $_SERVER[ $header ] )[0] );
+				if ( $ip ) {
+					return $ip;
+				}
+			}
+		}
+
+		// Final fallback to REMOTE_ADDR
+		return $_SERVER['REMOTE_ADDR'] ?? null;
+	}
+}

--- a/wordpress/plugins/cookie-analytics/includes/class-cookie-analytics-db.php
+++ b/wordpress/plugins/cookie-analytics/includes/class-cookie-analytics-db.php
@@ -1,0 +1,303 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Cookie_Analytics_DB {
+
+	/**
+	 * Get the events table name.
+	 */
+	public static function events_table() {
+		global $wpdb;
+		return $wpdb->prefix . 'cookie_analytics';
+	}
+
+	/**
+	 * Get the blacklist table name.
+	 */
+	public static function blacklist_table() {
+		global $wpdb;
+		return $wpdb->prefix . 'cookie_analytics_blacklist';
+	}
+
+	/**
+	 * Create the database tables on plugin activation.
+	 */
+	public static function create_tables() {
+		global $wpdb;
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$events_table    = self::events_table();
+		$blacklist_table = self::blacklist_table();
+
+		$sql_events = "CREATE TABLE $events_table (
+			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			event_type VARCHAR(20) NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			INDEX idx_event_type (event_type),
+			INDEX idx_created_at (created_at)
+		) $charset_collate;";
+
+		$sql_blacklist = "CREATE TABLE $blacklist_table (
+			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			ip_address VARCHAR(45) NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE INDEX idx_ip (ip_address)
+		) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql_events );
+		dbDelta( $sql_blacklist );
+	}
+
+	/**
+	 * Insert a new event record.
+	 *
+	 * @param string $event_type One of: impression, accept, reject, personalize.
+	 * @return bool|int False on failure, number of rows inserted on success.
+	 */
+	public static function insert_event( $event_type ) {
+		global $wpdb;
+
+		$allowed_types = [ 'impression', 'accept', 'reject', 'personalize' ];
+		if ( ! in_array( $event_type, $allowed_types, true ) ) {
+			return false;
+		}
+
+		return $wpdb->insert(
+			self::events_table(),
+			[
+				'event_type' => $event_type,
+				'created_at' => current_time( 'mysql' ),
+			],
+			[ '%s', '%s' ]
+		);
+	}
+
+	/**
+	 * Get aggregated event counts for a date range.
+	 *
+	 * @param string|null $start_date Start date (Y-m-d). Null for all time.
+	 * @param string|null $end_date   End date (Y-m-d). Null for all time.
+	 * @return array Associative array of event_type => count.
+	 */
+	public static function get_event_counts( $start_date = null, $end_date = null ) {
+		global $wpdb;
+		$table = self::events_table();
+
+		$where = '';
+		$params = [];
+
+		if ( $start_date && $end_date ) {
+			$where = 'WHERE created_at >= %s AND created_at < %s';
+			$params[] = $start_date . ' 00:00:00';
+			$params[] = date( 'Y-m-d', strtotime( $end_date . ' +1 day' ) ) . ' 00:00:00';
+		} elseif ( $start_date ) {
+			$where = 'WHERE created_at >= %s';
+			$params[] = $start_date . ' 00:00:00';
+		} elseif ( $end_date ) {
+			$where = 'WHERE created_at < %s';
+			$params[] = date( 'Y-m-d', strtotime( $end_date . ' +1 day' ) ) . ' 00:00:00';
+		}
+
+		$sql = "SELECT event_type, COUNT(*) as count FROM $table $where GROUP BY event_type";
+
+		if ( ! empty( $params ) ) {
+			$sql = $wpdb->prepare( $sql, $params );
+		}
+
+		$results = $wpdb->get_results( $sql, ARRAY_A );
+
+		$counts = [
+			'impression'  => 0,
+			'accept'      => 0,
+			'reject'      => 0,
+			'personalize' => 0,
+		];
+
+		if ( $results ) {
+			foreach ( $results as $row ) {
+				$counts[ $row['event_type'] ] = (int) $row['count'];
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Get daily event counts for charting.
+	 *
+	 * @param string|null $start_date Start date (Y-m-d).
+	 * @param string|null $end_date   End date (Y-m-d).
+	 * @return array Array of [ date => [ event_type => count ] ].
+	 */
+	public static function get_daily_counts( $start_date = null, $end_date = null ) {
+		global $wpdb;
+		$table = self::events_table();
+
+		$where = '';
+		$params = [];
+
+		if ( $start_date && $end_date ) {
+			$where = 'WHERE created_at >= %s AND created_at < %s';
+			$params[] = $start_date . ' 00:00:00';
+			$params[] = date( 'Y-m-d', strtotime( $end_date . ' +1 day' ) ) . ' 00:00:00';
+		} elseif ( $start_date ) {
+			$where = 'WHERE created_at >= %s';
+			$params[] = $start_date . ' 00:00:00';
+		} elseif ( $end_date ) {
+			$where = 'WHERE created_at < %s';
+			$params[] = date( 'Y-m-d', strtotime( $end_date . ' +1 day' ) ) . ' 00:00:00';
+		}
+
+		$sql = "SELECT DATE(created_at) as date, event_type, COUNT(*) as count
+				FROM $table
+				$where
+				GROUP BY DATE(created_at), event_type
+				ORDER BY date ASC";
+
+		if ( ! empty( $params ) ) {
+			$sql = $wpdb->prepare( $sql, $params );
+		}
+
+		$results = $wpdb->get_results( $sql, ARRAY_A );
+
+		$daily = [];
+		if ( $results ) {
+			foreach ( $results as $row ) {
+				$date = $row['date'];
+				if ( ! isset( $daily[ $date ] ) ) {
+					$daily[ $date ] = [
+						'impression'  => 0,
+						'accept'      => 0,
+						'reject'      => 0,
+						'personalize' => 0,
+					];
+				}
+				$daily[ $date ][ $row['event_type'] ] = (int) $row['count'];
+			}
+		}
+
+		return $daily;
+	}
+
+	/**
+	 * Check if an IP is blacklisted.
+	 *
+	 * @param string $ip IP address to check.
+	 * @return bool True if blacklisted.
+	 */
+	public static function is_ip_blacklisted( $ip ) {
+		global $wpdb;
+		$table = self::blacklist_table();
+
+		$result = $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM $table WHERE ip_address = %s", $ip )
+		);
+
+		return (int) $result > 0;
+	}
+
+	/**
+	 * Get all blacklisted IPs.
+	 *
+	 * @return array Array of blacklist records.
+	 */
+	public static function get_blacklist() {
+		global $wpdb;
+		$table = self::blacklist_table();
+
+		return $wpdb->get_results( "SELECT * FROM $table ORDER BY created_at DESC", ARRAY_A );
+	}
+
+	/**
+	 * Add an IP to the blacklist.
+	 *
+	 * @param string $ip IP address to blacklist.
+	 * @return bool|int False on failure, number of rows on success.
+	 */
+	public static function add_to_blacklist( $ip ) {
+		global $wpdb;
+
+		$ip = sanitize_text_field( trim( $ip ) );
+		if ( ! filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return false;
+		}
+
+		return $wpdb->replace(
+			self::blacklist_table(),
+			[
+				'ip_address' => $ip,
+				'created_at' => current_time( 'mysql' ),
+			],
+			[ '%s', '%s' ]
+		);
+	}
+
+	/**
+	 * Remove an IP from the blacklist.
+	 *
+	 * @param int $id Blacklist record ID.
+	 * @return bool|int False on failure, number of rows deleted on success.
+	 */
+	public static function remove_from_blacklist( $id ) {
+		global $wpdb;
+
+		return $wpdb->delete(
+			self::blacklist_table(),
+			[ 'id' => (int) $id ],
+			[ '%d' ]
+		);
+	}
+
+	/**
+	 * Delete all analytics event data.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public static function truncate_events() {
+		global $wpdb;
+		$table = self::events_table();
+
+		return $wpdb->query( "TRUNCATE TABLE $table" ) !== false;
+	}
+
+	/**
+	 * Delete events older than a given number of days.
+	 *
+	 * @param int $days Number of days to retain.
+	 * @return int|false Number of rows deleted, or false on failure.
+	 */
+	public static function delete_events_older_than( $days ) {
+		global $wpdb;
+		$table = self::events_table();
+		$days  = absint( $days );
+
+		return $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM $table WHERE created_at < DATE_SUB(NOW(), INTERVAL %d DAY)",
+				$days
+			)
+		);
+	}
+
+	/**
+	 * Get the configured retention period in days (0 = keep forever).
+	 *
+	 * @return int
+	 */
+	public static function get_retention_days() {
+		return (int) get_option( 'cookie_analytics_retention_days', 0 );
+	}
+
+	/**
+	 * Save the retention period.
+	 *
+	 * @param int $days Number of days (0 = keep forever).
+	 */
+	public static function set_retention_days( $days ) {
+		update_option( 'cookie_analytics_retention_days', absint( $days ) );
+	}
+}


### PR DESCRIPTION
## What?
Added a cookie analytics tracking and visualization system accessible from the WordPress admin panel.

## Why?
With Google Consent Mode v2, analytics data drops significantly for users who haven't yet accepted cookies -- and by definition, we can't track cookie acceptance through GA4 before consent is given. This creates a blind spot.
To address this, we built a server-side tracking system inside WordPress so that site administrators can see the full picture (banner impressions, acceptance rate, rejection rate) and cross-reference it with GA4 data.

## How?
**Next.js (frontend)**
- Added trackCookieEvent() calls in the GDPR banner component (impression, accept, reject, personalize)
- Created a /api/cookie-stats API route that proxies tracking requests to WordPress (avoids CORS issues, forwards visitor IP and User-Agent)

**WordPress (plugin: cookie-analytics)**
- Custom DB tables for event storage and IP blacklist
- REST API endpoint (POST /wp-json/supt/v1/cookie-stats) with input validation, bot detection, and IP blacklist filtering
**Admin page ("Cookie Analytics" top-level menu) featuring:**
- Date range filter (default: all time)
- Line chart (Chart.js) showing daily events over time
- Statistics table with counts and acceptance/rejection rates
- CSV export (respects current date filter)
- IP blacklist management (add/remove IPs to exclude from tracking)
- Danger zone: data retention settings (daily auto-cleanup via WP-Cron) and manual delete-all
## Testing
All features have been tested manually.

_> Note: If you want to test IP blacklisting locally, use ::1 as the IP address. In the local Docker setup, the real visitor IP is not available since requests are proxied through Next.js on localhost._
## Heads up
- A significant portion of the PHP code was AI-generated. I'm not the most experienced in PHP, so I'd appreciate a careful review -- especially around SQL queries, input sanitization, and any security concerns I might have missed.
- Bot filtering currently relies on a hardcoded list of User-Agent patterns. This works for common crawlers but will go stale over time. We could consider using a maintained library or external API  in a future iteration.