### PR TITLE
fix(graphql): escape host in resolve-uris preg_match pattern

### DIFF
--- a/wordpress/theme/includes/graphql/resolve-uris.php
+++ b/wordpress/theme/includes/graphql/resolve-uris.php
@@ -61,6 +61,11 @@ class ResolveUris {
 		$site_url = preg_replace('/https?:\/\//', '', get_site_url());
 		$next_url = preg_replace('/https?:\/\//', '', get_next_url());
 
+		// Escape the hosts: they can contain slashes (e.g. sub-path installs like
+		// "localhost/subsite"), which would otherwise be read as the regex delimiter.
+		$site_url = preg_quote($site_url, '/');
+		$next_url = preg_quote($next_url, '/');
+
 		// Do not continue if the result is not a BE nor a FE url
 		if (! preg_match("/^https?:\/\/($site_url|$next_url)/i", $result)) return $result;
 


### PR DESCRIPTION
## Problem

`graphql_resolve_relative_uris()` interpolates the site/FE hosts straight into a `preg_match` pattern:

```php
$site_url = preg_replace('/https?:\/\//', '', get_site_url());
$next_url = preg_replace('/https?:\/\//', '', get_next_url());

if (! preg_match("/^https?:\/\/($site_url|$next_url)/i", $result)) return $result;
```

The pattern uses `/` as its delimiter, but the interpolated hosts are **not escaped**. On a sub-path install the host contains a slash (e.g. `localhost/us`), so the first `/` inside the host is read as the closing delimiter and PHP parses the remainder (`us|localhost:3000...`) as modifiers — hitting the `|`:

```
PHP Warning: preg_match(): Unknown modifier '|' in .../graphql/resolve-uris.php on line 54
```

Because this filter runs on `graphql_resolve_field` for every `uri`/`url`/`link`/`guid`/`sourceUrl`/`mediaItemUrl` field, the warning (plus a full stack trace) is emitted on essentially every GraphQL request, flooding the logs.

It's a latent bug on root-domain installs (host has no slash) and only surfaces once the site runs under a sub-path — or if a host ever contains another regex-special char.

## Fix

Wrap both hosts in `preg_quote(..., '/')` so slashes and other regex-special characters are matched literally.

## Notes

- Behaviour is unchanged on root-domain installs; the pattern was previously broken/truncated on sub-path installs, so this also makes the host match actually correct there.
- These were `notice`/`warning`-level entries, not fatals — the site kept working, but the log noise (and per-request stack-trace overhead) is eliminated.
- Discovered on a downstream project (samantree.com) running under `/us`.
